### PR TITLE
add slack notification key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ python:
   - "3.4"
   - "3.5"
 
+# slack notification key
+ notifications:
+    slack: andela:5F0oqWhRsEmzKEmmfCPnhdxb
+
 # Manually define here the combinations environment variables to test
 # https://github.com/travis-ci/travis-ci/issues/1519
 env:


### PR DESCRIPTION
The branch contains the small chunks of code that we added in the .travis.yml file which serve to enable the slack integrations. 